### PR TITLE
Correct plugin URI in dependencies

### DIFF
--- a/manifest.imjoy.json
+++ b/manifest.imjoy.json
@@ -50,7 +50,7 @@
     "https://unpkg.com/spectre.css/dist/spectre-icons.min.css"
    ],
    "dependencies": [
-    "bionanoimaging/UC2-GIT/tree/master/SOFTWARE/IMJOY:UC2 Holorecon"
+    "bionanoimaging/UC2-ImJoy-GIT:UC2 Holorecon"
    ],
    "uri": "repository/UC2_Inline_Hologram_Reconstruction.imjoy.html"
   }

--- a/repository/UC2_Inline_Hologram_Reconstruction.imjoy.html
+++ b/repository/UC2_Inline_Hologram_Reconstruction.imjoy.html
@@ -30,7 +30,7 @@ and can thus also contain more complex data which can not be send by the plugin 
     "https://unpkg.com/spectre.css/dist/spectre-exp.min.css",
     "https://unpkg.com/spectre.css/dist/spectre-icons.min.css"
   ],
-  "dependencies": ["bionanoimaging/UC2-GIT/tree/master/SOFTWARE/IMJOY:UC2 Holorecon"]
+  "dependencies": ["bionanoimaging/UC2-ImJoy-GIT:UC2 Holorecon"]
 }
 </config>
 


### PR DESCRIPTION
Since you have manifest.imjoy.json already in the root of your repo, you can use imjoy plugin URI format: `GITHUB_USER_NAME/REPO_NAME:PLUGIN_NAME`. 

The correct plugin URI should be: `bionanoimaging/UC2-ImJoy-GIT:UC2 Holorecon`

Or absolute url: `https://github.com/bionanoimaging/UC2-ImJoy-GIT/blob/master/repository/UC2_Holorecon.imjoy.html`

Reference docs: https://imjoy.io/docs/#/development?id=generating-a-plugin-url-for-sharing 


The plugin URI is not only used by dependencies, but also you can use it to share the plugin, for example: [https://imjoy.io/#/app?plugin=bionanoimaging/UC2-ImJoy-GIT:Process Inline Hologram](https://imjoy.io/#/app?plugin=bionanoimaging/UC2-ImJoy-GIT:Process%20Inline%20Hologram)